### PR TITLE
Put screenshots in a table

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ shaders used by this demo.
 
 # Screenshots
   
-Main Screen | Alarms Screen |
-:----------:|:-------------:|
-<img src="assets/keynote_demo_1.png" width="300" /> | <img src="assets/keynote_demo_2.png" width="300" /> |
+<p>
+  <img alt="Main Screen" src="assets/keynote_demo_1.png" width="350px" />
+  <img alt="Alarms Screen" src="assets/keynote_demo_2.png" width="350px" />
+</p>
                                                                                                       
 ## License
 


### PR DESCRIPTION
I've put screenshots in a table as they are huge and take so much space in the README. This also makes readability hard. 

At the moment, the table is left-aligned but can make it centered, too.